### PR TITLE
Implement automatic test discovery

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -282,22 +282,9 @@ set(JAVA_MAIN_CLASSES
 )
 
 set(JAVA_TEST_CLASSES
-  src/test/java/org/rocksdb/BackupEngineTest.java
-  src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
-  src/test/java/org/rocksdb/NativeComparatorWrapperTest.java
-  src/test/java/org/rocksdb/PlatformRandomHelper.java
-  src/test/java/org/rocksdb/RocksDBExceptionTest.java
-  src/test/java/org/rocksdb/RocksNativeLibraryResource.java
-  src/test/java/org/rocksdb/SnapshotTest.java
-  src/test/java/org/rocksdb/WriteBatchTest.java
-  src/test/java/org/rocksdb/util/CapturingWriteBatchHandler.java
-  src/test/java/org/rocksdb/util/WriteBatchGetter.java
-  src/test/java/org/rocksdb/test/TestableEventListener.java
-)
-
-set(JAVA_ALL_TEST_CLASSES
-  ## From Makefile
+  src/test/java/org/rocksdb/AbstractTransactionTest.java
   src/test/java/org/rocksdb/BackupEngineOptionsTest.java
+  src/test/java/org/rocksdb/BackupEngineTest.java
   src/test/java/org/rocksdb/BlobOptionsTest.java
   src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
   src/test/java/org/rocksdb/BuiltinComparatorTest.java
@@ -306,6 +293,7 @@ set(JAVA_ALL_TEST_CLASSES
   src/test/java/org/rocksdb/ClockCacheTest.java
   src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
   src/test/java/org/rocksdb/ColumnFamilyTest.java
+  src/test/java/org/rocksdb/CompactRangeOptionsTest.java
   src/test/java/org/rocksdb/CompactionFilterFactoryTest.java
   src/test/java/org/rocksdb/CompactionJobInfoTest.java
   src/test/java/org/rocksdb/CompactionJobStatsTest.java
@@ -324,8 +312,10 @@ set(JAVA_ALL_TEST_CLASSES
   src/test/java/org/rocksdb/EnvOptionsTest.java
   src/test/java/org/rocksdb/EventListenerTest.java
   src/test/java/org/rocksdb/FilterTest.java
+  src/test/java/org/rocksdb/FlushOptionsTest.java
   src/test/java/org/rocksdb/FlushTest.java
   src/test/java/org/rocksdb/InfoLogLevelTest.java
+  src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
   src/test/java/org/rocksdb/KeyMayExistTest.java
   src/test/java/org/rocksdb/LRUCacheTest.java
   src/test/java/org/rocksdb/LoggerTest.java
@@ -338,6 +328,7 @@ set(JAVA_ALL_TEST_CLASSES
   src/test/java/org/rocksdb/MutableColumnFamilyOptionsTest.java
   src/test/java/org/rocksdb/MutableDBOptionsTest.java
   src/test/java/org/rocksdb/MutableOptionsGetSetTest.java
+  src/test/java/org/rocksdb/NativeComparatorWrapperTest.java
   src/test/java/org/rocksdb/NativeLibraryLoaderTest.java
   src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
   src/test/java/org/rocksdb/OptimisticTransactionOptionsTest.java
@@ -345,20 +336,25 @@ set(JAVA_ALL_TEST_CLASSES
   src/test/java/org/rocksdb/OptionsTest.java
   src/test/java/org/rocksdb/OptionsUtilTest.java
   src/test/java/org/rocksdb/PlainTableConfigTest.java
+  src/test/java/org/rocksdb/PlatformRandomHelper.java
   src/test/java/org/rocksdb/RateLimiterTest.java
   src/test/java/org/rocksdb/ReadOnlyTest.java
   src/test/java/org/rocksdb/ReadOptionsTest.java
+  src/test/java/org/rocksdb/RocksDBExceptionTest.java
   src/test/java/org/rocksdb/RocksDBTest.java
   src/test/java/org/rocksdb/RocksIteratorTest.java
   src/test/java/org/rocksdb/RocksMemEnvTest.java
+  src/test/java/org/rocksdb/RocksNativeLibraryResource.java
   src/test/java/org/rocksdb/SecondaryDBTest.java
   src/test/java/org/rocksdb/SliceTest.java
+  src/test/java/org/rocksdb/SnapshotTest.java
   src/test/java/org/rocksdb/SstFileManagerTest.java
   src/test/java/org/rocksdb/SstFileReaderTest.java
   src/test/java/org/rocksdb/SstFileWriterTest.java
   src/test/java/org/rocksdb/SstPartitionerTest.java
   src/test/java/org/rocksdb/StatisticsCollectorTest.java
   src/test/java/org/rocksdb/StatisticsTest.java
+  src/test/java/org/rocksdb/StatsCallbackMock.java
   src/test/java/org/rocksdb/TableFilterTest.java
   src/test/java/org/rocksdb/TimedEnvTest.java
   src/test/java/org/rocksdb/TransactionDBOptionsTest.java
@@ -367,35 +363,32 @@ set(JAVA_ALL_TEST_CLASSES
   src/test/java/org/rocksdb/TransactionOptionsTest.java
   src/test/java/org/rocksdb/TransactionTest.java
   src/test/java/org/rocksdb/TtlDBTest.java
+  src/test/java/org/rocksdb/Types.java
   src/test/java/org/rocksdb/VerifyChecksumsTest.java
   src/test/java/org/rocksdb/WALRecoveryModeTest.java
   src/test/java/org/rocksdb/WalFilterTest.java
   src/test/java/org/rocksdb/WriteBatchHandlerTest.java
+  src/test/java/org/rocksdb/WriteBatchTest.java
   src/test/java/org/rocksdb/WriteBatchThreadedTest.java
   src/test/java/org/rocksdb/WriteBatchWithIndexTest.java
   src/test/java/org/rocksdb/WriteOptionsTest.java
+  src/test/java/org/rocksdb/test/RemoveEmptyValueCompactionFilterFactory.java
+  src/test/java/org/rocksdb/test/RocksJunitRunner.java
+  src/test/java/org/rocksdb/test/SMRocksJunitRunner.java
+  src/test/java/org/rocksdb/test/TestableEventListener.java
+  src/test/java/org/rocksdb/util/ByteBufferAllocator.java
   src/test/java/org/rocksdb/util/BytewiseComparatorIntTest.java
   src/test/java/org/rocksdb/util/BytewiseComparatorTest.java
+  src/test/java/org/rocksdb/util/CapturingWriteBatchHandler.java
+  src/test/java/org/rocksdb/util/DirectByteBufferAllocator.java
   src/test/java/org/rocksdb/util/EnvironmentTest.java
+  src/test/java/org/rocksdb/util/HeapByteBufferAllocator.java
   src/test/java/org/rocksdb/util/IntComparatorTest.java
   src/test/java/org/rocksdb/util/JNIComparatorTest.java
   src/test/java/org/rocksdb/util/ReverseBytewiseComparatorIntTest.java
   src/test/java/org/rocksdb/util/SizeUnitTest.java
-
-  ## From file system:
-  src/test/java/org/rocksdb/AbstractTransactionTest.java
-  src/test/java/org/rocksdb/CompactRangeOptionsTest.java
-  src/test/java/org/rocksdb/FlushOptionsTest.java
-  src/test/java/org/rocksdb/StatsCallbackMock.java
-  src/test/java/org/rocksdb/Types.java
-  src/test/java/org/rocksdb/test/RemoveEmptyValueCompactionFilterFactory.java
-  src/test/java/org/rocksdb/test/RocksJunitRunner.java
-  src/test/java/org/rocksdb/test/SMRocksJunitRunner.java
-  src/test/java/org/rocksdb/util/ByteBufferAllocator.java
-  src/test/java/org/rocksdb/util/DirectByteBufferAllocator.java
-  src/test/java/org/rocksdb/util/HeapByteBufferAllocator.java
   src/test/java/org/rocksdb/util/TestUtil.java
-
+  src/test/java/org/rocksdb/util/WriteBatchGetter.java
 )
 
 include(FindJava)
@@ -432,7 +425,6 @@ elseif(${CMAKE_VERSION} VERSION_LESS "3.11.4")
       rocksdbjni_classes
       SOURCES
       ${JAVA_MAIN_CLASSES}
-      ${JAVA_TEST_CLASSES}
       INCLUDE_JARS ${JAVA_TESTCLASSPATH}
   )
 
@@ -443,7 +435,6 @@ else ()
       rocksdbjni_classes
       SOURCES
       ${JAVA_MAIN_CLASSES}
-      ${JAVA_TEST_CLASSES}
       INCLUDE_JARS ${JAVA_TESTCLASSPATH}
       GENERATE_NATIVE_HEADERS rocksdbjni_headers DESTINATION ${JNI_OUTPUT_DIR}
   )
@@ -452,7 +443,7 @@ endif()
 add_jar(
     rocksdbjni_test_classes
     SOURCES
-    ${JAVA_ALL_TEST_CLASSES}
+    ${JAVA_TEST_CLASSES}
     INCLUDE_JARS ${JAVA_TESTCLASSPATH} rocksdbjni_classes
     GENERATE_NATIVE_HEADERS rocksdbjni_test_headers DESTINATION ${JNI_OUTPUT_DIR}
   )

--- a/java/src/test/java/org/rocksdb/test/SMRocksJunitRunner.java
+++ b/java/src/test/java/org/rocksdb/test/SMRocksJunitRunner.java
@@ -1,51 +1,153 @@
 package org.rocksdb.test;
 
-public class SMRocksJunitRunner {
-  // This list has been copied from Makefile
-  private static final String[] TEST_CLASSES = new String[] {"org.rocksdb.BackupEngineOptionsTest",
-      "org.rocksdb.BackupEngineTest", "org.rocksdb.BlobOptionsTest",
-      "org.rocksdb.BlockBasedTableConfigTest", "org.rocksdb.BuiltinComparatorTest",
-      "org.rocksdb.BytewiseComparatorRegressionTest", "org.rocksdb.util.BytewiseComparatorTest",
-      "org.rocksdb.util.BytewiseComparatorIntTest", "org.rocksdb.CheckPointTest",
-      "org.rocksdb.ClockCacheTest", "org.rocksdb.ColumnFamilyOptionsTest",
-      "org.rocksdb.ColumnFamilyTest", "org.rocksdb.CompactionFilterFactoryTest",
-      "org.rocksdb.CompactionJobInfoTest", "org.rocksdb.CompactionJobStatsTest",
-      "org.rocksdb.CompactionOptionsTest", "org.rocksdb.CompactionOptionsFIFOTest",
-      "org.rocksdb.CompactionOptionsUniversalTest", "org.rocksdb.CompactionPriorityTest",
-      "org.rocksdb.CompactionStopStyleTest", "org.rocksdb.ComparatorOptionsTest",
-      "org.rocksdb.CompressionOptionsTest", "org.rocksdb.CompressionTypesTest",
-      "org.rocksdb.DBOptionsTest", "org.rocksdb.DirectSliceTest",
-      "org.rocksdb.util.EnvironmentTest", "org.rocksdb.EnvOptionsTest",
-      "org.rocksdb.EventListenerTest", "org.rocksdb.IngestExternalFileOptionsTest",
-      "org.rocksdb.util.IntComparatorTest", "org.rocksdb.util.JNIComparatorTest",
-      "org.rocksdb.FilterTest", "org.rocksdb.FlushTest", "org.rocksdb.InfoLogLevelTest",
-      "org.rocksdb.KeyMayExistTest", "org.rocksdb.ConcurrentTaskLimiterTest",
-      "org.rocksdb.LoggerTest", "org.rocksdb.LRUCacheTest", "org.rocksdb.MemoryUtilTest",
-      "org.rocksdb.MemTableTest", "org.rocksdb.MergeTest", "org.rocksdb.MultiGetManyKeysTest",
-      "org.rocksdb.MultiGetTest", "org.rocksdb.MixedOptionsTest",
-      "org.rocksdb.MutableColumnFamilyOptionsTest", "org.rocksdb.MutableDBOptionsTest",
-      "org.rocksdb.MutableOptionsGetSetTest", "org.rocksdb.NativeComparatorWrapperTest",
-      "org.rocksdb.NativeLibraryLoaderTest", "org.rocksdb.OptimisticTransactionTest",
-      "org.rocksdb.OptimisticTransactionDBTest", "org.rocksdb.OptimisticTransactionOptionsTest",
-      "org.rocksdb.OptionsUtilTest", "org.rocksdb.OptionsTest", "org.rocksdb.PlainTableConfigTest",
-      "org.rocksdb.RateLimiterTest", "org.rocksdb.ReadOnlyTest", "org.rocksdb.ReadOptionsTest",
-      "org.rocksdb.util.ReverseBytewiseComparatorIntTest", "org.rocksdb.RocksDBTest",
-      "org.rocksdb.RocksDBExceptionTest", "org.rocksdb.DefaultEnvTest",
-      "org.rocksdb.RocksIteratorTest", "org.rocksdb.RocksMemEnvTest",
-      "org.rocksdb.util.SizeUnitTest", "org.rocksdb.SecondaryDBTest", "org.rocksdb.SliceTest",
-      "org.rocksdb.SnapshotTest", "org.rocksdb.SstFileManagerTest", "org.rocksdb.SstFileWriterTest",
-      "org.rocksdb.SstFileReaderTest", "org.rocksdb.SstPartitionerTest",
-      "org.rocksdb.TableFilterTest", "org.rocksdb.TimedEnvTest", "org.rocksdb.TransactionTest",
-      "org.rocksdb.TransactionDBTest", "org.rocksdb.TransactionOptionsTest",
-      "org.rocksdb.TransactionDBOptionsTest", "org.rocksdb.TransactionLogIteratorTest",
-      "org.rocksdb.TtlDBTest", "org.rocksdb.StatisticsTest", "org.rocksdb.StatisticsCollectorTest",
-      "org.rocksdb.VerifyChecksumsTest", "org.rocksdb.WalFilterTest",
-      "org.rocksdb.WALRecoveryModeTest", "org.rocksdb.WriteBatchHandlerTest",
-      "org.rocksdb.WriteBatchTest", "org.rocksdb.WriteBatchThreadedTest",
-      "org.rocksdb.WriteOptionsTest", "org.rocksdb.WriteBatchWithIndexTest"};
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-  public static void main( String[] args) {
-    RocksJunitRunner.main(TEST_CLASSES);
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+public class SMRocksJunitRunner {
+  public static void main(String[] args) throws Exception {
+    String[] testClassNames;
+    if (args.length > 0) {
+      testClassNames = args;
+    } else {
+      List<String> classNamesList =
+          discoverClassNames(SMRocksJunitRunner.class);
+      List<String> testClassNamesList = filterTestClassNames(classNamesList);
+      Collections.sort(testClassNamesList);
+      testClassNames = testClassNamesList.toArray(new String[0]);
+    }
+    RocksJunitRunner.main(testClassNames);
   }
 
+  /**
+   * Discovers the names of all the classes that are siblings to the root class,
+   * whether in the same directory or the same JAR file.
+   *
+   * @param rootClass class to use to bootstrap the test discovery process.
+   *        Only tests in the same directory structure or JAR file will be
+   *        discovered.
+   * @returns the fully-qualified names of all discovered classes
+   * @throws Exception if there is a problem accessing the class files
+   */
+  private static List<String> discoverClassNames(Class<?> rootClass)
+      throws Exception {
+    String resourcePath = rootClass.getName().replace('.', '/') + ".class";
+    URL resourceUrl = rootClass.getClassLoader().getResource(resourcePath);
+    if (resourceUrl == null) {
+      // This should be impossible -- the class file for the root class should
+      // exist either on the filesystem or in a JAR.
+      throw new AssertionError(
+          "Cannot load class file for " + rootClass.getName());
+    }
+    final List<String> classNames = new ArrayList<>();
+    try (AutoCloseable fs = new DemandFileSystem(resourceUrl.toURI())) {
+      URI rootUri = new URI(resourceUrl.toString().replace(resourcePath, ""));
+      final Path rootPath = Paths.get(rootUri);
+      Set<FileVisitOption> options = Collections.emptySet();
+      Files.walkFileTree(
+          rootPath,
+          options,
+          Integer.MAX_VALUE,
+          new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(
+                Path path, BasicFileAttributes attrs) throws IOException {
+              String suffix = ".class";
+              if (path.toString().endsWith(suffix)) {
+                String relativePath = rootPath.relativize(path).toString();
+                int endIndex = relativePath.length() - suffix.length();
+                String classPath = relativePath.substring(0, endIndex);
+                classNames.add(classPath.replace('/', '.'));
+              }
+              return FileVisitResult.CONTINUE;
+            }
+          });
+    }
+    return classNames;
+  }
+
+  /**
+   * Returns the names of all the provided classes that can be used as Junit 4
+   * test classes.
+   */
+  private static List<String> filterTestClassNames(List<String> classNames) {
+    List<String> testClassNames = new ArrayList<>();
+    for (String className : classNames) {
+      Class<?> clazz;
+      try {
+        clazz = Class.forName(className);
+      } catch (ReflectiveOperationException e) {
+        System.err.println("Failed to load class " + className);
+        continue;
+      }
+      if (Modifier.isAbstract(clazz.getModifiers())) {
+        continue; // Cannot instantiate.
+      }
+      if (clazz.getAnnotation(RunWith.class) != null) {
+        testClassNames.add(className);
+        continue; // Using a custom runner, should work.
+      }
+      try {
+        clazz.getConstructor();
+      } catch (NoSuchMethodException e) {
+        continue; // Cannot instantiate.
+      }
+      for (Method method : clazz.getMethods()) {
+        if (method.getAnnotation(Test.class) != null) {
+          testClassNames.add(className);
+          break;
+        }
+      }
+    }
+    return testClassNames;
+  }
+
+  /**
+   * A wrapper that opens a new filesystem if necessary to access a URI.
+   * Newly-opened filesystems are closed when the DemandFileSystem object
+   * is closed.
+   */
+  private static class DemandFileSystem implements AutoCloseable {
+    final FileSystem fileSystem;
+
+    DemandFileSystem(URI uri) throws IOException {
+      FileSystem tempFileSystem = null;
+      try {
+        // Check if the filesystem is already open.
+        FileSystems.getFileSystem(uri);
+      } catch (FileSystemNotFoundException e) {
+        // We need to open a new filesystem.
+        Map<String, ?> env = Collections.emptyMap();
+        tempFileSystem = FileSystems.newFileSystem(uri, env);
+      }
+      this.fileSystem = tempFileSystem;
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (fileSystem != null) {
+        fileSystem.close();
+      }
+    }
+  }
 }


### PR DESCRIPTION
The list of tests in SMRocksJunitRunner was copied manually from the Makefile, so it will not be updated when new tests are added upstream. Even if new tests are included in the test JAR, they still will not be picked up. This could lead us to inadvertently break new functionality with our changes.

This commit adds a small test discovery implementation to the test runner. The test discovery mechanism is used unless a list of test classes are specified on the command line. The discovery code works for both JARs and directories of class files, so it can (theoretically) be run without rebuilding the JAR.