### PR TITLE
Rename "rocksdbjni-shared" target to "rocksdbjni"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,12 @@ jobs:
             EXTRA="-DROCKSDB_BUILD_SHARED=ON -DFAIL_ON_WARNINGS=OFF"
             cmake  -B build $TOOLS -DCMAKE_BUILD_TYPE=Release  $(cat ../deps/cmake-flags) -DPORTABLE=1
             grep ^WITH build/CMakeCache.txt
-            cmake --build  build -v -t  rocksdbjni-shared  --config Release -j 12
+            cmake --build  build -v -t rocksdbjni  --config Release -j 12
       - run:
           name: Copy dll
           command: |
             set -xe
-            mkdir jars && cp build/java/Release/rocksdbjni-shared.dll jars/librocksdbjni-win64.dll
+            mkdir jars && cp build/java/Release/rocksdbjni.dll jars/librocksdbjni-win64.dll
       - persist_to_workspace:
           root: .
           paths:
@@ -81,12 +81,12 @@ jobs:
             EXTRA="-DROCKSDB_BUILD_SHARED=ON -DFAIL_ON_WARNINGS=OFF"
             ${CMAKE_BIN-cmake}  -B build $TOOLS -DCMAKE_BUILD_TYPE=Release  $(cat ../deps/cmake-flags) -DCMAKE_OSX_ARCHITECTURES=$ARCH -DPORTABLE=1
             grep ^WITH build/CMakeCache.txt
-            ${CMAKE_BIN-cmake} --build  build -v -t  rocksdbjni-shared  --config Release -j 12
+            ${CMAKE_BIN-cmake} --build  build -v -t rocksdbjni  --config Release -j 12
       - run:
           name: Copy jnilib
           command: |
             set -xe
-            mkdir -p jars && cp build/java/librocksdbjni-shared.dylib jars/librocksdbjni-osx-$ARCH.jnilib
+            mkdir -p jars && cp build/java/librocksdbjni.dylib jars/librocksdbjni-osx-$ARCH.jnilib
 
       - persist_to_workspace:
           root: .
@@ -121,12 +121,12 @@ jobs:
             EXTRA="-DROCKSDB_BUILD_SHARED=ON -DFAIL_ON_WARNINGS=OFF"
             ${CMAKE_BIN-cmake}  -B build $TOOLS -DCMAKE_BUILD_TYPE=Release  $(cat ../deps/cmake-flags) -DCMAKE_OSX_ARCHITECTURES=$ARCH -DPORTABLE=1 -DHAS_ARMV8_CRC=1
             grep ^WITH build/CMakeCache.txt
-            ${CMAKE_BIN-cmake} --build  build -v -t  rocksdbjni-shared  --config Release -j 12
+            ${CMAKE_BIN-cmake} --build  build -v -t rocksdbjni  --config Release -j 12
       - run:
           name: Copy jnilib
           command: |
             set -xe
-            mkdir -p jars && cp build/java/librocksdbjni-shared.dylib jars/librocksdbjni-osx-$ARCH.jnilib
+            mkdir -p jars && cp build/java/librocksdbjni.dylib jars/librocksdbjni-osx-$ARCH.jnilib
 
       - persist_to_workspace:
           root: .
@@ -147,13 +147,13 @@ jobs:
             EXTRA="-DROCKSDB_BUILD_SHARED=ON -DFAIL_ON_WARNINGS=OFF"
             ${CMAKE_BIN-cmake}  -B build $TOOLS -DCMAKE_BUILD_TYPE=Release  $(cat ../deps/cmake-flags) -DPORTABLE=1
             grep ^WITH build/CMakeCache.txt
-            ${CMAKE_BIN-cmake} --build  build -v -t  rocksdbjni-shared  --config Release -j 12
+            ${CMAKE_BIN-cmake} --build  build -v -t rocksdbjni  --config Release -j 12
       - run:
           name: Copy dll and test jars
           command: |
             set -xe
             mkdir jars
-            cp build/java/librocksdbjni-shared.so jars/librocksdbjni-linux64.so
+            cp build/java/librocksdbjni.so jars/librocksdbjni-linux64.so
             cp build/java/rocksdbjni_classes.jar jars/
             mkdir test-jars/
             cp java/test-libs/*.jar test-jars/

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -643,26 +643,20 @@ if(NOT MSVC)
   set_property(TARGET ${ROCKSDB_STATIC_LIB} PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
-set(ROCKSDBJNI_STATIC_LIB rocksdbjni${ARTIFACT_SUFFIX})
-add_library(${ROCKSDBJNI_STATIC_LIB} ${JNI_NATIVE_SOURCES})
-add_dependencies(${ROCKSDBJNI_STATIC_LIB} rocksdbjni_headers rocksdbjni_test_headers)
-target_link_libraries(${ROCKSDBJNI_STATIC_LIB} ${ROCKSDB_STATIC_LIB} ${ROCKSDB_LIB})
-
-if(NOT MINGW)
-  set(ROCKSDBJNI_SHARED_LIB rocksdbjni-shared${ARTIFACT_SUFFIX})
-  add_library(${ROCKSDBJNI_SHARED_LIB} SHARED ${JNI_NATIVE_SOURCES})
-  add_dependencies(${ROCKSDBJNI_SHARED_LIB} rocksdbjni_headers rocksdbjni_test_headers)
-  target_link_libraries(${ROCKSDBJNI_SHARED_LIB} ${ROCKSDB_STATIC_LIB})
-
-  set_target_properties(
-    ${ROCKSDBJNI_SHARED_LIB}
-    PROPERTIES
-    COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_CFG_INTDIR}
-    COMPILE_PDB_NAME ${ROCKSDBJNI_STATIC_LIB}.pdb
-  )
+if(MINGW)
+  message("The rocksdbjni build is not known to work on MinGW")
 endif()
 
-
+set(ROCKSDBJNI_SHARED_LIB rocksdbjni${ARTIFACT_SUFFIX})
+add_library(${ROCKSDBJNI_SHARED_LIB} SHARED ${JNI_NATIVE_SOURCES})
+add_dependencies(${ROCKSDBJNI_SHARED_LIB} rocksdbjni_headers rocksdbjni_test_headers)
+target_link_libraries(${ROCKSDBJNI_SHARED_LIB} ${ROCKSDB_STATIC_LIB})
+set_target_properties(
+  ${ROCKSDBJNI_SHARED_LIB}
+  PROPERTIES
+  COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_CFG_INTDIR}
+  COMPILE_PDB_NAME ${ROCKSDBJNI_STATIC_LIB}.pdb
+)
 
 
 #list( TRANSFORM JAVA_TEST_CLASSES REPLACE  "src/test/java/([^ ]*).java" "\\1" OUTPUT_VARIABLE testfilebase )


### PR DESCRIPTION
The Java code expects the default JNI library to be named "librocksdbjni.so" or the equivalent, not "librocksdbjni-shared.so". This commit renames the build target so that it's easy to run the build output from the command line or IntelliJ without renaming the shared library.

(Technically, this removes the ability to build a static JNI library. In practice, I've never heard of anyone using a static JNI library; while it's technically possible, it requires rebuilding and relinking the JVM. Also yeah, this could cause conflicts — I think I need to kick off a discussion about upstreaming some of these changes after Thanksgiving.)