### PR TITLE
Fix ChecksumType::kXXH3 in the Java API (#10862)

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -4,7 +4,7 @@ if(${CMAKE_VERSION} VERSION_LESS "3.11.4")
     message("Please consider switching to CMake 3.11.4 or newer")
 endif()
 
-set(CMAKE_JAVA_COMPILE_FLAGS -source 7)
+set(CMAKE_JAVA_COMPILE_FLAGS -source 8)
 
 set(JNI_NATIVE_SOURCES
         rocksjni/backup_engine_options.cc

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -6654,6 +6654,8 @@ class ChecksumTypeJni {
         return ROCKSDB_NAMESPACE::ChecksumType::kxxHash;
       case 0x3:
         return ROCKSDB_NAMESPACE::ChecksumType::kxxHash64;
+      case 0x4:
+        return ROCKSDB_NAMESPACE::ChecksumType::kXXH3;
       default:
         // undefined/default
         return ROCKSDB_NAMESPACE::ChecksumType::kCRC32c;


### PR DESCRIPTION
### Commentary:
This is a patch that has been committed to facebook/main, but has not yet been included in a released version. It fixes a bug in the JNI binding that prevented us from using the fact XXH3 checksum to validate blocks instead of the slower CRC32c checksum. Using the faster checksum is helpful specifically in cases where the working set exceeds the size of the RocksDB block cache, but still fits in the page cache — in particular, block checksums are a bottleneck for deduplicating input records in the RawQ Topic source for efmw-jcp.

---
### Upstream Summary:
While PR#9749 nominally added support for XXH3 in the Java API, it did not update the `toCppChecksumType` method. As a result, setting the checksum type to XXH3 actually set it to CRC32c instead.

This commit adds the missing entry to portal.h, and also updates the tests so that they verify the options passed to RocksDB, instead of simply checking that the getter returns the value set by the setter.

Pull Request resolved: https://github.com/facebook/rocksdb/pull/10862

Reviewed By: pdillinger

Differential Revision: D40665031

Pulled By: ajkr

fbshipit-source-id: 2834419b3361a4bac47db3b858951fb451b5bdc8