### PR TITLE
Add SizeApproximationOptions to the JNI binding

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -121,6 +121,7 @@
 ### Java API Changes
 * Add CompactionPriority.RoundRobin.
 * Revert to using the default metadata charge policy when creating an LRU cache via the Java API.
+* Add SizeApproximationOptions for RocksDB#getApproximateSizes().
 
 ### Behavior Change
 * DBOptions::verify_sst_unique_id_in_manifest is now an on-by-default feature that verifies SST file identity whenever they are opened by a DB, rather than only at DB::Open time.

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -215,6 +215,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/RocksObject.java
   src/main/java/org/rocksdb/SanityLevel.java
   src/main/java/org/rocksdb/SizeApproximationFlag.java
+  src/main/java/org/rocksdb/SizeApproximationOptions.java
   src/main/java/org/rocksdb/SkipListMemTableConfig.java
   src/main/java/org/rocksdb/Slice.java
   src/main/java/org/rocksdb/Snapshot.java
@@ -574,6 +575,7 @@ if(${CMAKE_VERSION} VERSION_LESS "3.11.4")
           org.rocksdb.RocksMemEnv
           org.rocksdb.RocksMutableObject
           org.rocksdb.RocksObject
+          org.rocksdb.SizeApproximationOptions
           org.rocksdb.SkipListMemTableConfig
           org.rocksdb.Slice
           org.rocksdb.Snapshot

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -348,6 +348,7 @@ set(JAVA_TEST_CLASSES
   src/test/java/org/rocksdb/RocksMemEnvTest.java
   src/test/java/org/rocksdb/RocksNativeLibraryResource.java
   src/test/java/org/rocksdb/SecondaryDBTest.java
+  src/test/java/org/rocksdb/SizeApproximationOptionsTest.java
   src/test/java/org/rocksdb/SliceTest.java
   src/test/java/org/rocksdb/SnapshotTest.java
   src/test/java/org/rocksdb/SstFileManagerTest.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -61,6 +61,7 @@ NATIVE_JAVA_CLASSES = \
 	org.rocksdb.RocksEnv\
 	org.rocksdb.RocksIterator\
 	org.rocksdb.RocksMemEnv\
+	org.rocksdb.SizeApproximationOptions\
 	org.rocksdb.SkipListMemTableConfig\
 	org.rocksdb.Slice\
 	org.rocksdb.SstFileManager\
@@ -172,6 +173,7 @@ JAVA_TESTS = \
 	org.rocksdb.RocksMemEnvTest\
 	org.rocksdb.util.SizeUnitTest\
 	org.rocksdb.SecondaryDBTest\
+	org.rocksdb.SizeApproximationOptionsTest\
 	org.rocksdb.SliceTest\
 	org.rocksdb.SnapshotTest\
 	org.rocksdb.SstFileManagerTest\

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -21,6 +21,7 @@
 #include "include/org_rocksdb_FlushOptions.h"
 #include "include/org_rocksdb_Options.h"
 #include "include/org_rocksdb_ReadOptions.h"
+#include "include/org_rocksdb_SizeApproximationOptions.h"
 #include "include/org_rocksdb_WriteOptions.h"
 #include "rocksdb/comparator.h"
 #include "rocksdb/convenience.h"
@@ -8684,4 +8685,105 @@ void Java_org_rocksdb_FlushOptions_disposeInternal(JNIEnv*, jobject,
   auto* flush_opt = reinterpret_cast<ROCKSDB_NAMESPACE::FlushOptions*>(jhandle);
   assert(flush_opt != nullptr);
   delete flush_opt;
+}
+
+/////////////////////////////////////////////////////////////////////
+// ROCKSDB_NAMESPACE::SizeApproximationOptions
+
+/*
+ * Class:     org_rocksdb_SizeApproximationOptions
+ * Method:    newSizeApproximationOptions
+ * Signature: ()J
+ */
+jlong Java_org_rocksdb_SizeApproximationOptions_newSizeApproximationOptions(
+    JNIEnv*, jclass) {
+  auto* approx_options = new ROCKSDB_NAMESPACE::SizeApproximationOptions();
+  return GET_CPLUSPLUS_POINTER(approx_options);
+}
+
+/*
+ * Class:     org_rocksdb_SizeApproximationOptions
+ * Method:    setIncludeMemtables
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_SizeApproximationOptions_setIncludeMemtables(
+    JNIEnv*, jobject, jlong jhandle, jboolean jinclude_memtables) {
+  auto* approx_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SizeApproximationOptions*>(jhandle);
+  approx_options->include_memtables = jinclude_memtables == JNI_TRUE;
+}
+
+/*
+ * Class:     org_rocksdb_SizeApproximationOptions
+ * Method:    includeMemtables
+ * Signature: (J)Z
+ */
+jboolean JNICALL Java_org_rocksdb_SizeApproximationOptions_includeMemtables(
+    JNIEnv*, jobject, jlong jhandle) {
+  auto* approx_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SizeApproximationOptions*>(jhandle);
+  return static_cast<jboolean>(approx_options->include_memtables);
+}
+
+/*
+ * Class:     org_rocksdb_SizeApproximationOptions
+ * Method:    setIncludeFiles
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_SizeApproximationOptions_setIncludeFiles(
+    JNIEnv*, jobject, jlong jhandle, jboolean jinclude_files) {
+  auto* approx_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SizeApproximationOptions*>(jhandle);
+  approx_options->include_files = jinclude_files == JNI_TRUE;
+}
+
+/*
+ * Class:     org_rocksdb_SizeApproximationOptions
+ * Method:    includeFiles
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_SizeApproximationOptions_includeFiles(JNIEnv*,
+                                                                jobject,
+                                                                jlong jhandle) {
+  auto* approx_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SizeApproximationOptions*>(jhandle);
+  return static_cast<jboolean>(approx_options->include_files);
+}
+
+/*
+ * Class:     org_rocksdb_SizeApproximationOptions
+ * Method:    setFilesSizeErrorMargin
+ * Signature: (JD)V
+ */
+void Java_org_rocksdb_SizeApproximationOptions_setFilesSizeErrorMargin(
+    JNIEnv*, jobject, jlong jhandle, jdouble jfiles_size_error_margin) {
+  auto* approx_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SizeApproximationOptions*>(jhandle);
+  approx_options->files_size_error_margin =
+      static_cast<double>(jfiles_size_error_margin);
+}
+
+/*
+ * Class:     org_rocksdb_SizeApproximationOptions
+ * Method:    filesSizeErrorMargin
+ * Signature: (J)D
+ */
+jdouble Java_org_rocksdb_SizeApproximationOptions_filesSizeErrorMargin(
+    JNIEnv*, jobject, jlong jhandle) {
+  auto* approx_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SizeApproximationOptions*>(jhandle);
+  return static_cast<jdouble>(approx_options->files_size_error_margin);
+}
+
+/*
+ * Class:     org_rocksdb_SizeApproximationOptions
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_SizeApproximationOptions_disposeInternal(JNIEnv*, jobject,
+                                                               jlong jhandle) {
+  auto* approx_opt =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SizeApproximationOptions*>(jhandle);
+  assert(approx_opt != nullptr);
+  delete approx_opt;
 }

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -3205,6 +3205,47 @@ public class RocksDB extends RocksObject {
    * if the user data compresses by a factor of ten, the returned
    * sizes will be one-tenth the size of the corresponding user data size.
    *
+   * @param ranges the ranges over which to approximate sizes
+   * @param sizeApproximationOptions options which determine how to calculate
+   *     the approximation.
+   *
+   * @return the sizes
+   */
+  public long[] getApproximateSizes(
+      final List<Range> ranges, final SizeApproximationOptions sizeApproximationOptions) {
+    return getApproximateSizes(null, ranges, sizeApproximationOptions);
+  }
+
+  /**
+   * Get the approximate file system space used by keys in each range.
+   *
+   * Note that the returned sizes measure file system space usage, so
+   * if the user data compresses by a factor of ten, the returned
+   * sizes will be one-tenth the size of the corresponding user data size.
+   *
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
+   *     instance, or {@code null} for the default column family
+   * @param ranges the ranges over which to approximate sizes
+   * @param sizeApproximationOptions options which determine how to calculate
+   *     the approximation.
+   *
+   * @return the sizes
+   */
+  public long[] getApproximateSizes(
+      /*@Nullable*/ final ColumnFamilyHandle columnFamilyHandle, final List<Range> ranges,
+      final SizeApproximationOptions sizeApproximationOptions) {
+    return getApproximateSizes(nativeHandle_,
+        columnFamilyHandle == null ? 0 : columnFamilyHandle.nativeHandle_,
+        toRangeSliceHandles(ranges), sizeApproximationOptions.nativeHandle_);
+  }
+
+  /**
+   * Get the approximate file system space used by keys in each range.
+   *
+   * Note that the returned sizes measure file system space usage, so
+   * if the user data compresses by a factor of ten, the returned
+   * sizes will be one-tenth the size of the corresponding user data size.
+   *
    * If {@code sizeApproximationFlags} defines whether the returned size
    * should include the recently written data in the mem-tables (if
    * the mem-table type supports it), data serialized to disk, or both.
@@ -4562,6 +4603,8 @@ public class RocksDB extends RocksObject {
       throws RocksDBException;
   private native long getAggregatedLongProperty(final long nativeHandle,
       final String property, int propertyLength) throws RocksDBException;
+  private native long[] getApproximateSizes(final long nativeHandle, final long columnFamilyHandle,
+      final long[] rangeSliceHandles, final long sizeApproximationOptionsHandle);
   private native long[] getApproximateSizes(final long nativeHandle,
       final long columnFamilyHandle, final long[] rangeSliceHandles,
       final byte includeFlags);

--- a/java/src/main/java/org/rocksdb/SizeApproximationOptions.java
+++ b/java/src/main/java/org/rocksdb/SizeApproximationOptions.java
@@ -1,0 +1,131 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import java.util.List;
+
+/**
+ * SizeApproximationOptions to be passed to
+ * {@link RocksDB#getApproximateSizes(ColumnFamilyHandle, List, SizeApproximationOptions)}.
+ */
+public class SizeApproximationOptions extends RocksObject {
+  static {
+    RocksDB.loadLibrary();
+  }
+
+  /**
+   * Construct a new instance of SizeApproximationOptions.
+   */
+  public SizeApproximationOptions() {
+    super(newSizeApproximationOptions());
+  }
+
+  /**
+   * Set whether the returned size should include the recently written
+   * data in the memtables.
+   *
+   * Defaults to {@code false}.
+   *
+   * @param includeMemtables boolean value indicating whether the returned
+   *     size should include data in memtables. If set to {@code false},
+   *     then {@code includeFiles} must be {@code true}.
+   *
+   * @return this {@code SizeApproximationOptions} object
+   */
+  public SizeApproximationOptions setIncludeMemtables(final boolean includeMemtables) {
+    assert (isOwningHandle());
+    setIncludeMemtables(nativeHandle_, includeMemtables);
+    return this;
+  }
+
+  /**
+   * Include size of data in memtables.
+   *
+   * @return boolean value indicating if the returned size will include data
+   *     in memtables
+   */
+  public boolean includeMemtables() {
+    assert (isOwningHandle());
+    return includeMemtables(nativeHandle_);
+  }
+
+  /**
+   * Set whether the returned size should include data serialized to disk.
+   *
+   * Defaults to {@code true}.
+   *
+   * @param includeFiles boolean value indicating whether the returned size
+   *     should include data serialized to disk. If set to {@code false}, then
+   *     {@code includeMemtables} must be {@code true}.
+   *
+   * @return this {@code SizeApproximationOptions} object
+   */
+  public SizeApproximationOptions setIncludeFiles(final boolean includeFiles) {
+    assert (isOwningHandle());
+    setIncludeFiles(nativeHandle_, includeFiles);
+    return this;
+  }
+
+  /**
+   * Include size data in files.
+   *
+   * @return boolean value indicating if the returned size will include data
+   *     serialized to disk.
+   */
+  public boolean includeFiles() {
+    assert (isOwningHandle());
+    return includeFiles(nativeHandle_);
+  }
+
+  /**
+   * Sets the maximum error margin for the estimated total file size.
+   *
+   * Defaults to {@code -1.0}.
+   *
+   * When approximating the files' size that is used to store a key range
+   * using {@link RocksDB#getApproximateSizes(ColumnFamilyHandle, List, SizeApproximationOptions)},
+   * allow approximation with an error margin of up to
+   * {@code totalFilesSize * filesSizeErrorMargin}. This allows some
+   * shortcuts in files size approximation, resulting in better performance,
+   * while guaranteeing the resulting error is within the requested margin.
+   *
+   * For example, if the value is 0.1, then the error margin of the returned
+   * files size approximation will be within 10%. If the value is non-positive,
+   * a more precise yet more CPU intensive estimation is performed.
+   *
+   * @param filesSizeErrorMargin the maximum error margin for the total
+   *     file size estimate
+   *
+   * @return this {@code SizeApproximationOptions} object
+   */
+  public SizeApproximationOptions setFilesSizeErrorMargin(final double filesSizeErrorMargin) {
+    assert (isOwningHandle());
+    setFilesSizeErrorMargin(nativeHandle_, filesSizeErrorMargin);
+    return this;
+  }
+
+  /**
+   * Maximum error margin for the estimated total file size. Negative
+   * values mean that the system must perform a more precise estimate at
+   * the cost of additional CPU.
+   *
+   * @return maximum error margin for the estimated file size
+   */
+  public double filesSizeErrorMargin() {
+    assert (isOwningHandle());
+    return filesSizeErrorMargin(nativeHandle_);
+  }
+
+  private native static long newSizeApproximationOptions();
+  @Override protected final native void disposeInternal(final long handle);
+
+  private native void setIncludeMemtables(final long handle, final boolean includeMemtables);
+  private native boolean includeMemtables(final long handle);
+  private native void setIncludeFiles(final long handle, final boolean includeFiles);
+  private native boolean includeFiles(final long handle);
+  private native void setFilesSizeErrorMargin(final long handle, final double filesSizeErrorMargin);
+  private native double filesSizeErrorMargin(final long handle);
+}

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -1181,30 +1181,208 @@ public class RocksDBTest {
     }
   }
 
+  // RocksDB#getApproximateSizes() using SizeApproximationFlag.
   @Test
-  public void getApproximateSizes() throws RocksDBException {
+  public void getApproximateSizesFlag() throws RocksDBException {
+    final String dbPath = dbFolder.getRoot().getAbsolutePath();
     final byte key1[] = "key1".getBytes(UTF_8);
     final byte key2[] = "key2".getBytes(UTF_8);
     final byte key3[] = "key3".getBytes(UTF_8);
-    try (final Options options = new Options().setCreateIfMissing(true)) {
-      final String dbPath = dbFolder.getRoot().getAbsolutePath();
-      try (final RocksDB db = RocksDB.open(options, dbPath)) {
-        db.put(key1, key1);
-        db.put(key2, key2);
-        db.put(key3, key3);
+    try (final Options options = new Options().setCreateIfMissing(true);
+         final FlushOptions flushOptions = new FlushOptions();
+         final RocksDB db = RocksDB.open(options, dbPath); final Slice slice1 = new Slice(key1);
+         final Slice slice2 = new Slice(key2); final Slice slice3 = new Slice(key3)) {
+      db.put(key1, key1);
 
-        final long[] sizes = db.getApproximateSizes(
-            Arrays.asList(
-                new Range(new Slice(key1), new Slice(key1)),
-                new Range(new Slice(key2), new Slice(key3))
-            ),
-            SizeApproximationFlag.INCLUDE_FILES,
-            SizeApproximationFlag.INCLUDE_MEMTABLES);
+      // Size in memory (i.e. key1.)
+      long[] memorySizes = db.getApproximateSizes(
+          Arrays.asList(new Range(slice1, slice3)), SizeApproximationFlag.INCLUDE_MEMTABLES);
+      assertThat(memorySizes.length).isEqualTo(1);
+      assertThat(memorySizes[0]).isGreaterThanOrEqualTo(1);
 
-        assertThat(sizes.length).isEqualTo(2);
-        assertThat(sizes[0]).isEqualTo(0);
-        assertThat(sizes[1]).isGreaterThanOrEqualTo(1);
-      }
+      // Size on disk (i.e. nothing.)
+      long[] diskSizes = db.getApproximateSizes(
+          Arrays.asList(new Range(slice1, slice3)), SizeApproximationFlag.INCLUDE_FILES);
+      assertThat(diskSizes.length).isEqualTo(1);
+      assertThat(diskSizes[0]).isEqualTo(0);
+
+      // Size in both memory and on disk should match in-memory size.
+      long[] combinedSizes = db.getApproximateSizes(Arrays.asList(new Range(slice1, slice3)),
+          SizeApproximationFlag.INCLUDE_MEMTABLES, SizeApproximationFlag.INCLUDE_FILES);
+      assertThat(combinedSizes.length).isEqualTo(1);
+      assertThat(combinedSizes[0]).isEqualTo(memorySizes[0]);
+
+      db.flush(flushOptions);
+
+      // Size in memory (i.e. nothing.)
+      memorySizes = db.getApproximateSizes(
+          Arrays.asList(new Range(slice1, slice3)), SizeApproximationFlag.INCLUDE_MEMTABLES);
+      assertThat(memorySizes.length).isEqualTo(1);
+      assertThat(memorySizes[0]).isEqualTo(0);
+
+      // Size on disk (i.e. key1.)
+      diskSizes = db.getApproximateSizes(
+          Arrays.asList(new Range(slice1, slice3)), SizeApproximationFlag.INCLUDE_FILES);
+      assertThat(diskSizes.length).isEqualTo(1);
+      assertThat(diskSizes[0]).isGreaterThanOrEqualTo(1);
+
+      // Size in both memory and on disk should match on-disk size.
+      combinedSizes = db.getApproximateSizes(Arrays.asList(new Range(slice1, slice3)),
+          SizeApproximationFlag.INCLUDE_MEMTABLES, SizeApproximationFlag.INCLUDE_FILES);
+      assertThat(combinedSizes.length).isEqualTo(1);
+      assertThat(combinedSizes[0]).isEqualTo(diskSizes[0]);
+
+      db.put(key2, key2);
+      db.put(key3, key3);
+
+      // Re-check the size in memory.
+      memorySizes = db.getApproximateSizes(
+          Arrays.asList(new Range(slice1, slice3)), SizeApproximationFlag.INCLUDE_MEMTABLES);
+      assertThat(memorySizes.length).isEqualTo(1);
+      assertThat(memorySizes[0]).isGreaterThanOrEqualTo(1);
+
+      // Re-check the combined size. It should include both data in memory
+      // and data on disk.
+      combinedSizes = db.getApproximateSizes(Arrays.asList(new Range(slice1, slice3)),
+          SizeApproximationFlag.INCLUDE_MEMTABLES, SizeApproximationFlag.INCLUDE_FILES);
+      assertThat(combinedSizes.length).isEqualTo(1);
+      assertThat(combinedSizes[0]).isEqualTo(diskSizes[0] + memorySizes[0]);
+
+      // Check size in multiple ranges.
+      final long[] multipleSizes = db.getApproximateSizes(
+          Arrays.asList(new Range(slice1, slice1), new Range(slice2, slice3)),
+          SizeApproximationFlag.INCLUDE_FILES, SizeApproximationFlag.INCLUDE_MEMTABLES);
+      assertThat(multipleSizes.length).isEqualTo(2);
+      assertThat(multipleSizes[0]).isEqualTo(0);
+      assertThat(multipleSizes[1]).isGreaterThanOrEqualTo(1);
+    }
+  }
+
+  // RocksDB#getApproximateSizes() using SizeApproximationOptions.
+  @Test
+  public void getApproximateSizesOptions() throws RocksDBException {
+    final String dbPath = dbFolder.getRoot().getAbsolutePath();
+    final byte key1[] = "key1".getBytes(UTF_8);
+    final byte key2[] = "key2".getBytes(UTF_8);
+    final byte key3[] = "key3".getBytes(UTF_8);
+    try (final Options options = new Options().setCreateIfMissing(true);
+         final FlushOptions flushOptions = new FlushOptions();
+         final RocksDB db = RocksDB.open(options, dbPath);
+         final SizeApproximationOptions approxOptions = new SizeApproximationOptions();
+         final Slice slice1 = new Slice(key1); final Slice slice2 = new Slice(key2);
+         final Slice slice3 = new Slice(key3)) {
+      db.put(key1, key1);
+
+      // Size in memory (i.e. key1.)
+      approxOptions.setIncludeMemtables(true);
+      approxOptions.setIncludeFiles(false);
+      long[] memorySizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(memorySizes.length).isEqualTo(1);
+      assertThat(memorySizes[0]).isGreaterThanOrEqualTo(1);
+
+      // Size on disk (i.e. nothing.)
+      approxOptions.setIncludeMemtables(false);
+      approxOptions.setIncludeFiles(true);
+      long[] diskSizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(diskSizes.length).isEqualTo(1);
+      assertThat(diskSizes[0]).isEqualTo(0);
+
+      // Size in both memory and on disk should match in-memory size.
+      approxOptions.setIncludeMemtables(true);
+      approxOptions.setIncludeFiles(true);
+      long[] combinedSizes =
+          db.getApproximateSizes(Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(combinedSizes.length).isEqualTo(1);
+      assertThat(combinedSizes[0]).isEqualTo(memorySizes[0]);
+
+      db.flush(flushOptions);
+
+      // Size in memory (i.e. nothing.)
+      approxOptions.setIncludeMemtables(true);
+      approxOptions.setIncludeFiles(false);
+      memorySizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(memorySizes.length).isEqualTo(1);
+      assertThat(memorySizes[0]).isEqualTo(0);
+
+      // Size on disk (i.e. key1.)
+      approxOptions.setIncludeMemtables(false);
+      approxOptions.setIncludeFiles(true);
+      diskSizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(diskSizes.length).isEqualTo(1);
+      assertThat(diskSizes[0]).isGreaterThanOrEqualTo(1);
+
+      // Size in both memory and on disk should match on-disk size.
+      approxOptions.setIncludeMemtables(true);
+      approxOptions.setIncludeFiles(true);
+      combinedSizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(combinedSizes.length).isEqualTo(1);
+      assertThat(combinedSizes[0]).isEqualTo(diskSizes[0]);
+
+      db.put(key2, key2);
+      db.put(key3, key3);
+
+      // Re-check the size in memory.
+      approxOptions.setIncludeMemtables(true);
+      approxOptions.setIncludeFiles(false);
+      memorySizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(memorySizes.length).isEqualTo(1);
+      assertThat(memorySizes[0]).isGreaterThanOrEqualTo(1);
+
+      // Re-check the combined size. It should include both data in memory
+      // and data on disk.
+      approxOptions.setIncludeMemtables(true);
+      approxOptions.setIncludeFiles(true);
+      combinedSizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(combinedSizes.length).isEqualTo(1);
+      assertThat(combinedSizes[0]).isEqualTo(diskSizes[0] + memorySizes[0]);
+
+      // Check size in multiple ranges.
+      approxOptions.setIncludeMemtables(true);
+      approxOptions.setIncludeFiles(true);
+      final long[] multipleSizes = db.getApproximateSizes(
+          null, Arrays.asList(new Range(slice1, slice1), new Range(slice2, slice3)), approxOptions);
+      assertThat(multipleSizes.length).isEqualTo(2);
+      assertThat(multipleSizes[0]).isEqualTo(0);
+      assertThat(multipleSizes[1]).isGreaterThanOrEqualTo(1);
+
+      // Verify that setting the error margin doesn't prevent returning data.
+      db.flush(flushOptions);
+
+      approxOptions.setIncludeMemtables(false);
+      approxOptions.setIncludeFiles(true);
+      approxOptions.setFilesSizeErrorMargin(-1.0); // Compute accurately.
+      long[] preciseSizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(preciseSizes.length).isEqualTo(1);
+      assertThat(preciseSizes[0]).isGreaterThanOrEqualTo(1);
+
+      approxOptions.setFilesSizeErrorMargin(Double.POSITIVE_INFINITY);
+      long[] approxSizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice1, slice3)), approxOptions);
+      assertThat(approxSizes.length).isEqualTo(1);
+      assertThat(approxSizes[0]).isGreaterThanOrEqualTo(1);
+
+      // Verify that the error margin is passed through. An exact error
+      // margin should return 0 on an empty range, while an infinite error
+      // margin should return greater than zero.
+      approxOptions.setFilesSizeErrorMargin(-1.0); // Compute accurately.
+      preciseSizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice2, slice2)), approxOptions);
+      assertThat(preciseSizes.length).isEqualTo(1);
+      assertThat(preciseSizes[0]).isEqualTo(0);
+
+      approxOptions.setFilesSizeErrorMargin(Double.POSITIVE_INFINITY);
+      approxSizes =
+          db.getApproximateSizes(null, Arrays.asList(new Range(slice2, slice2)), approxOptions);
+      assertThat(approxSizes.length).isEqualTo(1);
+      assertThat(approxSizes[0]).isGreaterThanOrEqualTo(1);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/SizeApproximationOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/SizeApproximationOptionsTest.java
@@ -1,0 +1,39 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class SizeApproximationOptionsTest {
+  @Test
+  public void includeMemtables() {
+    try (final SizeApproximationOptions approxOptions = new SizeApproximationOptions()) {
+      assertThat(approxOptions.includeMemtables()).isFalse();
+      approxOptions.setIncludeMemtables(true);
+      assertThat(approxOptions.includeMemtables()).isTrue();
+    }
+  }
+
+  @Test
+  public void includeFiles() {
+    try (final SizeApproximationOptions approxOptions = new SizeApproximationOptions()) {
+      assertThat(approxOptions.includeFiles()).isTrue();
+      approxOptions.setIncludeFiles(false);
+      assertThat(approxOptions.includeFiles()).isFalse();
+    }
+  }
+
+  @Test
+  public void fileSizeErrorMargin() {
+    try (final SizeApproximationOptions approxOptions = new SizeApproximationOptions()) {
+      assertThat(approxOptions.filesSizeErrorMargin()).isEqualTo(-1.0);
+      approxOptions.setFilesSizeErrorMargin(25.5);
+      assertThat(approxOptions.filesSizeErrorMargin()).isEqualTo(25.5);
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the `SizeApproximationOptions` structure to the JNI binding, plus the corresponding overload for `RocksDB#getApproximateSizes()`. With this change, it is possible to set the size estimation error margin from Java — in particular, we want to be able to set the error margin to `+inf` to get order-of-magnitude estimates of how much data exists between two keys and can be immediately deleted.